### PR TITLE
Delete deprecated field 'last_ad_referral' in Graph API

### DIFF
--- a/src/main/java/com/github/messenger4j/Messenger.java
+++ b/src/main/java/com/github/messenger4j/Messenger.java
@@ -80,7 +80,7 @@ public final class Messenger {
     private static final String FB_GRAPH_API_URL_MESSAGES = "https://graph.facebook.com/v2.11/me/messages?access_token=%s";
     private static final String FB_GRAPH_API_URL_MESSENGER_PROFILE = "https://graph.facebook.com/v2.11/me/messenger_profile?access_token=%s";
     private static final String FB_GRAPH_API_URL_USER = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
-            "last_name,profile_pic,locale,timezone,gender,last_ad_referral&access_token=%s";
+            "last_name,profile_pic,locale,timezone,gender&access_token=%s";
 
     private final String pageAccessToken;
     private final String appSecret;


### PR DESCRIPTION
While requesting User Profile we catch MessengerApiException: (#12) last_ad_referral field is deprecated for versions v3.1 and higher

As a hotfix we can just remove last_ad_referral from the requested parameters in FB_GRAPH_API_URL_USER